### PR TITLE
feat: 카테고리 및 브랜드 등록 기능 + 401/403 예외 응답 커스터마이징

### DIFF
--- a/src/main/java/com/example/coupangclone/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/coupangclone/auth/jwt/JwtAuthenticationFilter.java
@@ -27,8 +27,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = jwtProvider.resolveToken(request);
 
         if (token != null) {
-            Claims info = jwtProvider.getUserInfoFromToken(token);
-            setAuthentication(info.getSubject());
+            if (jwtProvider.validationToken(token)){
+                Claims info = jwtProvider.getUserInfoFromToken(token);
+                setAuthentication(info.getSubject());
+            }
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/example/coupangclone/config/SecurityConfig.java
+++ b/src/main/java/com/example/coupangclone/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.example.coupangclone.config;
 
 import com.example.coupangclone.auth.jwt.JwtAuthenticationFilter;
+import com.example.coupangclone.global.exception.CustomAccessDeniedHandler;
+import com.example.coupangclone.global.exception.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +25,8 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -39,6 +43,11 @@ public class SecurityConfig {
                                 .requestMatchers("/api/signup", "/api/login").permitAll()
                                 .requestMatchers("/admin/**").hasRole("ADMIN")
                                 .anyRequest().authenticated()
+                        )
+                        .exceptionHandling(exception ->
+                                exception
+                                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                                        .accessDeniedHandler(customAccessDeniedHandler)
                         );
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/com/example/coupangclone/global/dto/ErrorResponseDto.java
+++ b/src/main/java/com/example/coupangclone/global/dto/ErrorResponseDto.java
@@ -7,15 +7,18 @@ import lombok.Getter;
 public class ErrorResponseDto {
 
     private int status;
+    private String type;
     private String msg;
 
-    public ErrorResponseDto(int status, String msg) {
+    public ErrorResponseDto(int status, String type, String msg) {
         this.status = status;
+        this.type = type;
         this.msg = msg;
     }
 
     public ErrorResponseDto(ExceptionEnum exceptionEnum) {
         this.status = exceptionEnum.getStatus();
+        this.type = exceptionEnum.getType();
         this.msg = exceptionEnum.getMsg();
     }
 

--- a/src/main/java/com/example/coupangclone/global/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/coupangclone/global/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package com.example.coupangclone.global.exception;
+
+import com.example.coupangclone.global.dto.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(ExceptionEnum.NOT_ALLOW);
+        String responseBody = objectMapper.writeValueAsString(errorResponseDto);
+
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/example/coupangclone/global/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/coupangclone/global/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package com.example.coupangclone.global.exception;
+
+import com.example.coupangclone.global.dto.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(ExceptionEnum.NEED_LOGIN);
+        String responseBody = objectMapper.writeValueAsString(errorResponseDto);
+
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/example/coupangclone/global/exception/ExceptionEnum.java
+++ b/src/main/java/com/example/coupangclone/global/exception/ExceptionEnum.java
@@ -12,7 +12,8 @@ public enum ExceptionEnum {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "만료된 JWT 토큰 입니다.", "JWT"),
     UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST.value(), "지원되지 않는 JWT 토큰 입니다.", "JWT"),
     WRONG_TOKEN(HttpStatus.BAD_REQUEST.value(), "잘못된 JWT 토근입니다.", "JWT"),
-    NOT_ALLOW(HttpStatus.BAD_REQUEST.value(), "권한이 없습니다.", "USER"),
+    NOT_ALLOW(HttpStatus.FORBIDDEN.value(), "권한이 없습니다.", "USER"),
+    NEED_LOGIN(HttpStatus.UNAUTHORIZED.value(), "인증이 필요합니다.", "USER"),
     CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "상위 카테고리가 존재하지 않습니다.", "ITEM");
 
     private final int status;

--- a/src/main/java/com/example/coupangclone/global/exception/ExceptionEnum.java
+++ b/src/main/java/com/example/coupangclone/global/exception/ExceptionEnum.java
@@ -14,7 +14,9 @@ public enum ExceptionEnum {
     WRONG_TOKEN(HttpStatus.BAD_REQUEST.value(), "잘못된 JWT 토근입니다.", "JWT"),
     NOT_ALLOW(HttpStatus.FORBIDDEN.value(), "권한이 없습니다.", "USER"),
     NEED_LOGIN(HttpStatus.UNAUTHORIZED.value(), "인증이 필요합니다.", "USER"),
-    CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "상위 카테고리가 존재하지 않습니다.", "ITEM");
+    CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "상위 카테고리가 존재하지 않습니다.", "ITEM"),
+    CATEGORY_DUPLICATION(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 카테고리입니다.", "ITEM"),
+    BRAND_DUPLICATION(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 브랜드입니다.", "ITEM");
 
     private final int status;
     private final String msg;

--- a/src/main/java/com/example/coupangclone/global/exception/ExceptionEnum.java
+++ b/src/main/java/com/example/coupangclone/global/exception/ExceptionEnum.java
@@ -11,7 +11,9 @@ public enum ExceptionEnum {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않는 JWT 서명 입니다.", "JWT"),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "만료된 JWT 토큰 입니다.", "JWT"),
     UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST.value(), "지원되지 않는 JWT 토큰 입니다.", "JWT"),
-    WRONG_TOKEN(HttpStatus.BAD_REQUEST.value(), "잘못된 JWT 토근입니다.", "JWT");
+    WRONG_TOKEN(HttpStatus.BAD_REQUEST.value(), "잘못된 JWT 토근입니다.", "JWT"),
+    NOT_ALLOW(HttpStatus.BAD_REQUEST.value(), "권한이 없습니다.", "USER"),
+    CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "상위 카테고리가 존재하지 않습니다.", "ITEM");
 
     private final int status;
     private final String msg;

--- a/src/main/java/com/example/coupangclone/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/coupangclone/global/exception/GlobalExceptionHandler.java
@@ -35,7 +35,9 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponseDto> handleErrorException(ErrorException e) {
         log.warn("[{} 예외]: {}", e.getExceptionEnum().getMsg());
 
-        ErrorResponseDto errorResponseDto = new ErrorResponseDto(e.getExceptionEnum().getStatus(), e.getExceptionEnum().getMsg());
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                e.getExceptionEnum().getStatus(), e.getExceptionEnum().getType(), e.getExceptionEnum().getMsg()
+        );
         return ResponseEntity.status(e.getExceptionEnum().getStatus()).body(errorResponseDto);
     }
 

--- a/src/main/java/com/example/coupangclone/item/controller/AdminItemController.java
+++ b/src/main/java/com/example/coupangclone/item/controller/AdminItemController.java
@@ -1,6 +1,7 @@
 package com.example.coupangclone.item.controller;
 
 import com.example.coupangclone.auth.userdetails.UserDetailsImpl;
+import com.example.coupangclone.item.dto.brand.BrandRequestDto;
 import com.example.coupangclone.item.dto.category.CategoryRequestDto;
 import com.example.coupangclone.item.service.AdminItemService;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,12 @@ public class AdminItemController {
     public ResponseEntity<?> createCategory(@RequestBody CategoryRequestDto requestDto,
                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return adminItemService.createCategory(requestDto, userDetails.getUser());
+    }
+
+    @PostMapping("/brand")
+    public ResponseEntity<?> createBrand(@RequestBody BrandRequestDto requestDto,
+                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return adminItemService.createBrand(requestDto, userDetails.getUser());
     }
 
 }

--- a/src/main/java/com/example/coupangclone/item/controller/AdminItemController.java
+++ b/src/main/java/com/example/coupangclone/item/controller/AdminItemController.java
@@ -1,0 +1,27 @@
+package com.example.coupangclone.item.controller;
+
+import com.example.coupangclone.auth.userdetails.UserDetailsImpl;
+import com.example.coupangclone.item.dto.category.CategoryRequestDto;
+import com.example.coupangclone.item.service.AdminItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/item")
+public class AdminItemController {
+
+    private final AdminItemService adminItemService;
+
+    @PostMapping("/category")
+    public ResponseEntity<?> createCategory(@RequestBody CategoryRequestDto requestDto,
+                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return adminItemService.createCategory(requestDto, userDetails.getUser());
+    }
+
+}

--- a/src/main/java/com/example/coupangclone/item/dto/brand/BrandRequestDto.java
+++ b/src/main/java/com/example/coupangclone/item/dto/brand/BrandRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.coupangclone.item.dto.brand;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BrandRequestDto {
+
+    private String name;
+
+}

--- a/src/main/java/com/example/coupangclone/item/dto/category/CategoryRequestDto.java
+++ b/src/main/java/com/example/coupangclone/item/dto/category/CategoryRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.coupangclone.item.dto.category;
+
+import com.example.coupangclone.item.entity.Category;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoryRequestDto {
+
+    private String name;
+    private Category parent;
+
+}

--- a/src/main/java/com/example/coupangclone/item/entity/Brand.java
+++ b/src/main/java/com/example/coupangclone/item/entity/Brand.java
@@ -1,0 +1,26 @@
+package com.example.coupangclone.item.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Brand {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "brand_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Builder
+    public Brand(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/main/java/com/example/coupangclone/item/entity/Category.java
+++ b/src/main/java/com/example/coupangclone/item/entity/Category.java
@@ -1,0 +1,30 @@
+package com.example.coupangclone.item.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private Category parent;
+
+    @Builder
+    public Category(String name, Category parent) {
+        this.name = name;
+        this.parent = parent;
+    }
+}

--- a/src/main/java/com/example/coupangclone/item/repository/BrandRepository.java
+++ b/src/main/java/com/example/coupangclone/item/repository/BrandRepository.java
@@ -1,0 +1,10 @@
+package com.example.coupangclone.item.repository;
+
+import com.example.coupangclone.item.entity.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BrandRepository extends JpaRepository<Brand, Long> {
+
+    boolean existsByName(String name);
+
+}

--- a/src/main/java/com/example/coupangclone/item/repository/CategoryRepository.java
+++ b/src/main/java/com/example/coupangclone/item/repository/CategoryRepository.java
@@ -4,4 +4,7 @@ import com.example.coupangclone.item.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    boolean existsByName(String name);
+
 }

--- a/src/main/java/com/example/coupangclone/item/repository/CategoryRepository.java
+++ b/src/main/java/com/example/coupangclone/item/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.example.coupangclone.item.repository;
+
+import com.example.coupangclone.item.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/example/coupangclone/item/service/AdminItemService.java
+++ b/src/main/java/com/example/coupangclone/item/service/AdminItemService.java
@@ -1,0 +1,46 @@
+package com.example.coupangclone.item.service;
+
+import com.example.coupangclone.global.dto.BasicResponseDto;
+import com.example.coupangclone.global.exception.ErrorException;
+import com.example.coupangclone.global.exception.ExceptionEnum;
+import com.example.coupangclone.item.dto.category.CategoryRequestDto;
+import com.example.coupangclone.item.entity.Category;
+import com.example.coupangclone.item.repository.CategoryRepository;
+import com.example.coupangclone.user.entity.User;
+import com.example.coupangclone.user.enums.UserRoleEnum;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminItemService {
+
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public ResponseEntity<?> createCategory(CategoryRequestDto requestDto, User user) {
+        checkAdmin(user);
+
+        Category parent = null;
+        if (requestDto.getParent() != null) {
+            parent = categoryRepository.findById(requestDto.getParent().getId()).orElseThrow(
+                    () -> new ErrorException(ExceptionEnum.CATEGORY_NOT_FOUND)
+            );
+        }
+        Category category = Category.builder()
+                .name(requestDto.getName())
+                .parent(parent)
+                .build();
+        categoryRepository.save(category);
+        return ResponseEntity.ok(BasicResponseDto.addSuccess("카테고리 등록이 완료되었습니다."));
+    }
+
+    private static void checkAdmin(User user) {
+        if (!user.getRole().equals(UserRoleEnum.ADMIN)) {
+            throw new ErrorException(ExceptionEnum.CATEGORY_NOT_FOUND);
+        }
+    }
+
+}

--- a/src/main/java/com/example/coupangclone/item/service/AdminItemService.java
+++ b/src/main/java/com/example/coupangclone/item/service/AdminItemService.java
@@ -3,8 +3,11 @@ package com.example.coupangclone.item.service;
 import com.example.coupangclone.global.dto.BasicResponseDto;
 import com.example.coupangclone.global.exception.ErrorException;
 import com.example.coupangclone.global.exception.ExceptionEnum;
+import com.example.coupangclone.item.dto.brand.BrandRequestDto;
 import com.example.coupangclone.item.dto.category.CategoryRequestDto;
+import com.example.coupangclone.item.entity.Brand;
 import com.example.coupangclone.item.entity.Category;
+import com.example.coupangclone.item.repository.BrandRepository;
 import com.example.coupangclone.item.repository.CategoryRepository;
 import com.example.coupangclone.user.entity.User;
 import com.example.coupangclone.user.enums.UserRoleEnum;
@@ -18,10 +21,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminItemService {
 
     private final CategoryRepository categoryRepository;
+    private final BrandRepository brandRepository;
 
     @Transactional
     public ResponseEntity<?> createCategory(CategoryRequestDto requestDto, User user) {
         checkAdmin(user);
+
+        if(categoryRepository.existsByName(requestDto.getName())) {
+             throw new ErrorException(ExceptionEnum.CATEGORY_DUPLICATION);
+        }
 
         Category parent = null;
         if (requestDto.getParent() != null) {
@@ -35,6 +43,21 @@ public class AdminItemService {
                 .build();
         categoryRepository.save(category);
         return ResponseEntity.ok(BasicResponseDto.addSuccess("카테고리 등록이 완료되었습니다."));
+    }
+
+    @Transactional
+    public ResponseEntity<?> createBrand(BrandRequestDto requestDto, User user) {
+        checkAdmin(user);
+
+        if (brandRepository.existsByName(requestDto.getName())) {
+            throw new ErrorException(ExceptionEnum.BRAND_DUPLICATION);
+        }
+
+        Brand brand = Brand.builder()
+                .name(requestDto.getName())
+                .build();
+        brandRepository.save(brand);
+        return ResponseEntity.ok(BasicResponseDto.addSuccess("브랜드 등록이 완료되었습니다."));
     }
 
     private static void checkAdmin(User user) {

--- a/src/main/java/com/example/coupangclone/user/enums/UserRoleEnum.java
+++ b/src/main/java/com/example/coupangclone/user/enums/UserRoleEnum.java
@@ -16,6 +16,6 @@ public enum UserRoleEnum {
 
     public static class Authority {
         public static final String USER = "ROLE_USER";
-        public static final String ADMIN = "ADMIN";
+        public static final String ADMIN = "ROLE_ADMIN";
     }
 }


### PR DESCRIPTION
# ✨ 구현 내용

## ✅ 카테고리 / 브랜드 등록 기능
- Category, Brand 엔티티 생성
- CategoryRepository, BrandRepository 생성 및 중복 체크 메서드 추가 (`existsByName`)
- CategoryRequestDto, BrandRequestDto 정의
- AdminItemService에 등록 로직 구현 (중복 시 Exception 발생)
- AdminItemController에 POST API 추가
- 관리자만 접근 가능하도록 `/admin/**` 경로에 권한 제한 설정

## ✅ 인증 / 인가 실패 응답 커스터마이징
- 401 Unauthorized: `CustomAuthenticationEntryPoint` 구현
  - 인증되지 않은 요청 시 JSON 형태로 `"인증이 필요합니다."` 응답 처리
- 403 Forbidden: `CustomAccessDeniedHandler` 구현
  - 권한 없는 사용자가 접근할 경우 `"권한이 없습니다."` 응답 처리
- `ErrorResponseDto`에 `type` 필드 추가
- `ExceptionEnum`에 `NEED_LOGIN`, `NOT_ALLOW`, `CATEGORY_DUPLICATION`, `BRAND_DUPLICATION` 등 예외 항목 추가
- SecurityConfig에 두 핸들러 등록

## 🧪 테스트

- Postman으로 카테고리/브랜드 등록 API 테스트
  - 중복된 name 값으로 요청 시 예외 응답 확인
  - 인증되지 않은 요청 시 401, 권한 없는 유저 요청 시 403 확인
- Authorization 헤더에 JWT 토큰 포함 시 정상 등록 가능

## 📌 기타

- 전역 예외 응답 포맷 통일 (`ErrorResponseDto(status, type, msg)`)
- 모든 예외를 일관된 JSON 구조로 내려주도록 구조 개선