### PR TITLE
feat(search-log): 검색어 저장 및 연관 검색어 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/coupangclone/item/controller/ItemController.java
+++ b/src/main/java/com/example/coupangclone/item/controller/ItemController.java
@@ -3,6 +3,7 @@ package com.example.coupangclone.item.controller;
 import com.example.coupangclone.auth.userdetails.UserDetailsImpl;
 import com.example.coupangclone.item.dto.item.ItemRequestDto;
 import com.example.coupangclone.item.dto.item.ItemResponseDto;
+import com.example.coupangclone.item.dto.item.SearchItemResponseDto;
 import com.example.coupangclone.item.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -39,7 +40,7 @@ public class ItemController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<Page<ItemResponseDto>> searchItems(@RequestParam("keyword") String keyword,
+    public ResponseEntity<SearchItemResponseDto> searchItems(@RequestParam("keyword") String keyword,
                                                              @PageableDefault(size = 10) Pageable pageable,
                                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return itemService.searchItems(keyword, pageable, userDetails.getUser());

--- a/src/main/java/com/example/coupangclone/item/dto/item/SearchItemResponseDto.java
+++ b/src/main/java/com/example/coupangclone/item/dto/item/SearchItemResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.coupangclone.item.dto.item;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SearchItemResponseDto {
+
+    private Page<ItemResponseDto> items;
+    List<String> relatedKeywords;
+
+}

--- a/src/main/java/com/example/coupangclone/item/entity/SearchLog.java
+++ b/src/main/java/com/example/coupangclone/item/entity/SearchLog.java
@@ -1,0 +1,35 @@
+package com.example.coupangclone.item.entity;
+
+import com.example.coupangclone.global.common.Timestamped;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SearchLog extends Timestamped {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ElementCollection
+    @CollectionTable(name = "search_keywords", joinColumns = @JoinColumn(name = "search_log_id"))
+    @Column(name = "keyword")
+    private List<String> keywords;
+
+    private String mainKeyword;
+
+    private String brand;
+
+    @Builder
+    public SearchLog(List<String> keywords, String mainKeyword, String brand) {
+        this.keywords = keywords;
+        this.mainKeyword = mainKeyword;
+        this.brand = brand;
+    }
+}

--- a/src/main/java/com/example/coupangclone/item/repository/BrandRepository.java
+++ b/src/main/java/com/example/coupangclone/item/repository/BrandRepository.java
@@ -3,8 +3,11 @@ package com.example.coupangclone.item.repository;
 import com.example.coupangclone.item.entity.Brand;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BrandRepository extends JpaRepository<Brand, Long> {
 
     boolean existsByName(String name);
+    Optional<Brand> findByName(String name);
 
 }

--- a/src/main/java/com/example/coupangclone/item/repository/ItemRepository.java
+++ b/src/main/java/com/example/coupangclone/item/repository/ItemRepository.java
@@ -1,5 +1,6 @@
 package com.example.coupangclone.item.repository;
 
+import com.example.coupangclone.item.entity.Brand;
 import com.example.coupangclone.item.entity.Item;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -7,10 +8,19 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
     @Query("SELECT i FROM Item i LEFT JOIN i.brand b " +
             "WHERE i.name LIKE %:keyword% OR (b IS NOT NULL AND b.name LIKE %:keyword%)")
     Page<Item> searchByNameOrBrand(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT i FROM Item i LEFT JOIN i.brand b " +
+            "WHERE LOWER(i.name) LIKE LOWER(%:keyword%) " +
+            "OR (b IS NOT NULL AND LOWER(b.name) LIKE LOWER(%:keyword%))")
+    List<Item> findMatchingItemsByNameOrBrand(@Param("keyword") String keyword);
+
+    List<Item> findTop5ByBrand(Brand brand);
 
 }

--- a/src/main/java/com/example/coupangclone/item/repository/SearchLogRepository.java
+++ b/src/main/java/com/example/coupangclone/item/repository/SearchLogRepository.java
@@ -1,0 +1,22 @@
+package com.example.coupangclone.item.repository;
+
+import com.example.coupangclone.item.entity.SearchLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface SearchLogRepository extends JpaRepository<SearchLog, Long> {
+
+    @Query(value = """
+            SELECT DISTINCT sk.keyword
+            FROM search_keywords sk
+            WHERE sk.keyword LIKE %:keyword%
+            GROUP BY sk.keyword
+            ORDER BY COUNT(sk.keyword) DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<String> findTopByKeywordContaining(@Param("keyword") String keyword, @Param("limit") int limit);
+
+}

--- a/src/main/java/com/example/coupangclone/item/service/SearchLogService.java
+++ b/src/main/java/com/example/coupangclone/item/service/SearchLogService.java
@@ -1,0 +1,103 @@
+package com.example.coupangclone.item.service;
+
+import com.example.coupangclone.item.entity.Brand;
+import com.example.coupangclone.item.entity.Item;
+import com.example.coupangclone.item.entity.SearchLog;
+import com.example.coupangclone.item.repository.BrandRepository;
+import com.example.coupangclone.item.repository.ItemRepository;
+import com.example.coupangclone.item.repository.SearchLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SearchLogService {
+
+    private final SearchLogRepository searchLogRepository;
+    private final BrandRepository brandRepository;
+    private final ItemRepository itemRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveKeyword(String keyword) {
+        if (!StringUtils.hasText(keyword)) return;
+
+        Optional<Brand> brandOpt = brandRepository.findByName(keyword);
+
+        if (brandOpt.isPresent()) {
+            Brand brand = brandOpt.get();
+
+            List<Item> brandItems = itemRepository.findTop5ByBrand(brand);
+            if (brandItems.isEmpty()) return;
+
+            List<String> itemNames = brandItems.stream()
+                    .map(Item::getName)
+                    .distinct()
+                    .limit(5)
+                    .toList();
+
+            SearchLog log = SearchLog.builder()
+                    .keywords(itemNames)
+                    .mainKeyword(brand.getName())
+                    .brand(brand.getName())
+                    .build();
+            searchLogRepository.save(log);
+            return;
+        }
+
+        List<Item> matchingItems = itemRepository.findMatchingItemsByNameOrBrand(keyword);
+        if (matchingItems.isEmpty()) return;
+
+        Brand existsBrand = matchingItems.stream()
+                .filter(item -> item.getBrand() != null)
+                .collect(Collectors.groupingBy(Item::getBrand, Collectors.counting()))
+                .entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+
+        String brandName = existsBrand != null ? existsBrand.getName() : null;
+
+        SearchLog log = SearchLog.builder()
+                .keywords(List.of(keyword))
+                .mainKeyword(keyword)
+                .brand(brandName)
+                .build();
+
+        searchLogRepository.save(log);
+    }
+
+
+    @Transactional(readOnly = true)
+    public List<String> getRelatedKeywordsFor(String keyword) {
+        if (!StringUtils.hasText(keyword)) return Collections.emptyList();
+
+        Optional<Brand> brandOpt = brandRepository.findByName(keyword);
+
+        if (brandOpt.isPresent()) {
+            Brand brand = brandOpt.get();
+            List<Item> brandItems = itemRepository.findTop5ByBrand(brand);
+            if (brandItems.isEmpty()) return List.of();
+
+            return brandItems.stream()
+                    .map(Item::getName)
+                    .flatMap(itemName ->
+                            searchLogRepository
+                                    .findTopByKeywordContaining(itemName, 3)
+                                    .stream())
+                    .filter(k -> !k.equalsIgnoreCase(keyword))
+                    .distinct()
+                    .limit(5)
+                    .toList();
+        }
+        return searchLogRepository.findTopByKeywordContaining(keyword, 5);
+    }
+}


### PR DESCRIPTION
## 구현 기능
- `SearchLog` 엔티티에 `keywords`, `mainKeyword`, `brand` 필드를 추가하여 검색어를 저장
- 사용자가 입력한 검색어에 대해 `SearchLog`에 기록하는 로직 추가
- `SearchLogService`에서 검색어를 기반으로 연관된 검색어를 조회하는 기능 추가

## 개선점
- 브랜드 추론 정확도 개선
- 사용자 행동 추적 로그 기능 개선