### PR TITLE
test: AdminItemService 카테고리 및 브랜드 등록 기능 테스트 추가

### DIFF
--- a/src/main/java/com/example/coupangclone/item/dto/brand/BrandRequestDto.java
+++ b/src/main/java/com/example/coupangclone/item/dto/brand/BrandRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.coupangclone.item.dto.brand;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,5 +9,10 @@ import lombok.NoArgsConstructor;
 public class BrandRequestDto {
 
     private String name;
+
+    @Builder
+    public BrandRequestDto(String name) {
+        this.name = name;
+    }
 
 }

--- a/src/main/java/com/example/coupangclone/item/dto/category/CategoryRequestDto.java
+++ b/src/main/java/com/example/coupangclone/item/dto/category/CategoryRequestDto.java
@@ -2,6 +2,7 @@ package com.example.coupangclone.item.dto.category;
 
 import com.example.coupangclone.item.entity.Category;
 import com.example.coupangclone.item.enums.ItemTypeEnum;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,5 +13,12 @@ public class CategoryRequestDto {
     private String name;
     private ItemTypeEnum type;
     private Category parent;
+
+    @Builder
+    public CategoryRequestDto(String name, ItemTypeEnum type, Category parent) {
+        this.name = name;
+        this.type = type;
+        this.parent = parent;
+    }
 
 }

--- a/src/main/java/com/example/coupangclone/item/service/AdminItemService.java
+++ b/src/main/java/com/example/coupangclone/item/service/AdminItemService.java
@@ -63,7 +63,7 @@ public class AdminItemService {
 
     private static void checkAdmin(User user) {
         if (!user.getRole().equals(UserRoleEnum.ADMIN)) {
-            throw new ErrorException(ExceptionEnum.PARENT_CATEGORY_NOT_FOUND);
+            throw new ErrorException(ExceptionEnum.NOT_ALLOW);
         }
     }
 

--- a/src/test/java/com/example/coupangclone/item/repository/BrandRepositoryTest.java
+++ b/src/test/java/com/example/coupangclone/item/repository/BrandRepositoryTest.java
@@ -1,0 +1,79 @@
+package com.example.coupangclone.item.repository;
+
+import com.example.coupangclone.item.entity.Brand;
+import com.example.coupangclone.user.entity.User;
+import com.example.coupangclone.user.enums.UserRoleEnum;
+import com.example.coupangclone.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BrandRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @DisplayName("이미 존재하는 브랜드라면 existsByName이 true를 반환한다.")
+    @Test
+    void existsBrand(){
+        // given
+        User user = User.builder()
+                .email("admin@example.com")
+                .password("qwer123!")
+                .name("관리자")
+                .tel("01012345678")
+                .gender("남성")
+                .role(UserRoleEnum.ADMIN)
+                .build();
+        userRepository.save(user);
+        Brand brand = Brand.builder()
+                .name("애플")
+                .build();
+        brandRepository.save(brand);
+
+        // when
+        boolean existsByName = brandRepository.existsByName("애플");
+
+        // then
+        assertThat(existsByName).isTrue();
+    }
+
+    @DisplayName("브랜드 이름으로 브랜드를 찾는다.")
+    @Test
+    void findByName(){
+        // given
+        User user = User.builder()
+                .email("admin@example.com")
+                .password("qwer123!")
+                .name("관리자")
+                .tel("01012345678")
+                .gender("남성")
+                .role(UserRoleEnum.ADMIN)
+                .build();
+        userRepository.save(user);
+        Brand brand = Brand.builder()
+                .name("애플")
+                .build();
+        brandRepository.save(brand);
+
+        // when
+        Optional<Brand> result = brandRepository.findByName("애플");
+
+        // then
+        assertThat(result).isPresent();
+    }
+
+}

--- a/src/test/java/com/example/coupangclone/item/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/example/coupangclone/item/repository/CategoryRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.example.coupangclone.item.repository;
+
+import com.example.coupangclone.item.entity.Category;
+import com.example.coupangclone.item.enums.ItemTypeEnum;
+import com.example.coupangclone.user.entity.User;
+import com.example.coupangclone.user.enums.UserRoleEnum;
+import com.example.coupangclone.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CategoryRepositoryTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("이미 존재하는 카테고리라면 existsByName이 true를 반환한다.")
+    @Test
+    void existsCategory(){
+        // given
+        User user = User.builder()
+                .email("admin@example.com")
+                .password("qwer123!")
+                .name("관리자")
+                .tel("01012345678")
+                .gender("남성")
+                .role(UserRoleEnum.ADMIN)
+                .build();
+        userRepository.save(user);
+        Category category = Category.builder()
+                .name("전자제품")
+                .type(ItemTypeEnum.THING)
+                .parent(null)
+                .build();
+        categoryRepository.save(category);
+
+        // when
+        boolean existsByName = categoryRepository.existsByName("전자제품");
+
+        // then
+        assertThat(existsByName).isTrue();
+    }
+
+}

--- a/src/test/java/com/example/coupangclone/item/service/AdminItemServiceTest.java
+++ b/src/test/java/com/example/coupangclone/item/service/AdminItemServiceTest.java
@@ -3,9 +3,12 @@ package com.example.coupangclone.item.service;
 import com.example.coupangclone.global.dto.BasicResponseDto;
 import com.example.coupangclone.global.exception.ErrorException;
 import com.example.coupangclone.global.exception.ExceptionEnum;
+import com.example.coupangclone.item.dto.brand.BrandRequestDto;
 import com.example.coupangclone.item.dto.category.CategoryRequestDto;
+import com.example.coupangclone.item.entity.Brand;
 import com.example.coupangclone.item.entity.Category;
 import com.example.coupangclone.item.enums.ItemTypeEnum;
+import com.example.coupangclone.item.repository.BrandRepository;
 import com.example.coupangclone.item.repository.CategoryRepository;
 import com.example.coupangclone.user.entity.User;
 import com.example.coupangclone.user.enums.UserRoleEnum;
@@ -31,16 +34,19 @@ class AdminItemServiceTest {
     private UserRepository userRepository;
     @Autowired
     private CategoryRepository categoryRepository;
+    @Autowired
+    private BrandRepository brandRepository;
 
     @AfterEach
     void tearDown() {
+        brandRepository.deleteAllInBatch();
         categoryRepository.deleteAllInBatch();
         userRepository.deleteAllInBatch();
     }
 
     @DisplayName("관리자가 카테고리를 등록하는데 성공한다.")
     @Test
-    void createCategory_success(){
+    void createCategory_success() {
         // given
         User admin =
                 createUser("admin@example.com", "qwer123!", "관리자", "01098765432", "남성");
@@ -60,7 +66,7 @@ class AdminItemServiceTest {
 
     @DisplayName("관리자가 아닌 회원이 카테고리를 등록하려하면 실패한다.")
     @Test
-    void createCategory_fail_not_admin(){
+    void createCategory_fail_not_admin() {
         // given
         User user = User.builder()
                 .email("user@example.com")
@@ -81,7 +87,7 @@ class AdminItemServiceTest {
 
     @DisplayName("존재하는 카테고리 등록 시 실패한다.")
     @Test
-    void createCategory_fail_existsCategory(){
+    void createCategory_fail_existsCategory() {
         // given
         User admin =
                 createUser("admin@example.com", "qwer123!", "관리자", "01098765432", "남성");
@@ -98,7 +104,7 @@ class AdminItemServiceTest {
 
     @DisplayName("카테고리의 상위 카테고리 등록 시 상위 카테고리가 존재하지 않으면 실패한다.")
     @Test
-    void createCategory_fail_not_found_parentCategory(){
+    void createCategory_fail_not_found_parentCategory() {
         // given
         User admin =
                 createUser("admin@example.com", "qwer123!", "관리자", "01098765432", "남성");
@@ -115,6 +121,72 @@ class AdminItemServiceTest {
         assertThatThrownBy(() -> adminItemService.createCategory(requestDto, admin))
                 .isInstanceOf(ErrorException.class)
                 .hasMessage(ExceptionEnum.CATEGORY_NOT_FOUND.getMsg());
+    }
+
+    @DisplayName("관리자가 브랜드를 등록하는데 성공한다.")
+    @Test
+    void createBrand_success() {
+        // given
+        User admin =
+                createUser("admin@example.com", "qwer123!", "관리자", "01098765432", "남성");
+        userRepository.save(admin);
+        BrandRequestDto requestDto = BrandRequestDto.builder()
+                .name("애플")
+                .build();
+
+        // when
+        ResponseEntity<?> response = adminItemService.createBrand(requestDto, admin);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isInstanceOf(BasicResponseDto.class);
+
+        BasicResponseDto responseDto = (BasicResponseDto) response.getBody();
+        assertThat(responseDto.getMsg()).isEqualTo("브랜드 등록이 완료되었습니다.");
+    }
+
+    @DisplayName("관리자가 아닌 회원이 브랜드를 등록하려하면 실패한다.")
+    @Test
+    void createBrand_fail_not_admin() {
+        // given
+        User user = User.builder()
+                .email("user@example.com")
+                .password("qwer123!")
+                .name("회원")
+                .tel("01032153215")
+                .gender("여성")
+                .role(UserRoleEnum.USER)
+                .build();
+        userRepository.save(user);
+        BrandRequestDto requestDto = BrandRequestDto.builder()
+                .name("애플")
+                .build();
+
+        // when // then
+        assertThatThrownBy(() -> adminItemService.createBrand(requestDto, user))
+                .isInstanceOf(ErrorException.class)
+                .hasMessage(ExceptionEnum.NOT_ALLOW.getMsg());
+    }
+
+    @DisplayName("존재하는 브랜드 등록 시 실패한다.")
+    @Test
+    void createBrand_fail_existsBrand() {
+        // given
+        User admin =
+                createUser("admin@example.com", "qwer123!", "관리자", "01098765432", "남성");
+        userRepository.save(admin);
+        BrandRequestDto requestDto = BrandRequestDto.builder()
+                .name("애플")
+                .build();
+        Brand brand = Brand.builder()
+                .name("애플")
+                .build();
+        brandRepository.save(brand);
+
+        // when // then
+        assertThatThrownBy(() -> adminItemService.createBrand(requestDto, admin))
+                .isInstanceOf(ErrorException.class)
+                .hasMessage(ExceptionEnum.BRAND_DUPLICATION.getMsg());
     }
 
 

--- a/src/test/java/com/example/coupangclone/item/service/AdminItemServiceTest.java
+++ b/src/test/java/com/example/coupangclone/item/service/AdminItemServiceTest.java
@@ -1,0 +1,148 @@
+package com.example.coupangclone.item.service;
+
+import com.example.coupangclone.global.dto.BasicResponseDto;
+import com.example.coupangclone.global.exception.ErrorException;
+import com.example.coupangclone.global.exception.ExceptionEnum;
+import com.example.coupangclone.item.dto.category.CategoryRequestDto;
+import com.example.coupangclone.item.entity.Category;
+import com.example.coupangclone.item.enums.ItemTypeEnum;
+import com.example.coupangclone.item.repository.CategoryRepository;
+import com.example.coupangclone.user.entity.User;
+import com.example.coupangclone.user.enums.UserRoleEnum;
+import com.example.coupangclone.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class AdminItemServiceTest {
+
+    @Autowired
+    private AdminItemService adminItemService;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @AfterEach
+    void tearDown() {
+        categoryRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("관리자가 카테고리를 등록하는데 성공한다.")
+    @Test
+    void createCategory_success(){
+        // given
+        User admin =
+                createUser("admin@example.com", "qwer123!", "관리자", "01098765432", "남성");
+        userRepository.save(admin);
+        CategoryRequestDto requestDto = createCategoryDto("전자제품", ItemTypeEnum.THING, null);
+
+        // when
+        ResponseEntity<?> response = adminItemService.createCategory(requestDto, admin);
+
+        // then
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isInstanceOf(BasicResponseDto.class);
+
+        BasicResponseDto responseDto = (BasicResponseDto) response.getBody();
+        assertThat(responseDto.getMsg()).isEqualTo("카테고리 등록이 완료되었습니다.");
+    }
+
+    @DisplayName("관리자가 아닌 회원이 카테고리를 등록하려하면 실패한다.")
+    @Test
+    void createCategory_fail_not_admin(){
+        // given
+        User user = User.builder()
+                .email("user@example.com")
+                .password("qwer123!")
+                .name("회원")
+                .tel("01032153215")
+                .gender("여성")
+                .role(UserRoleEnum.USER)
+                .build();
+        userRepository.save(user);
+        CategoryRequestDto requestDto = createCategoryDto("전자제품", ItemTypeEnum.THING, null);
+
+        // when // then
+        assertThatThrownBy(() -> adminItemService.createCategory(requestDto, user))
+                .isInstanceOf(ErrorException.class)
+                .hasMessage(ExceptionEnum.NOT_ALLOW.getMsg());
+    }
+
+    @DisplayName("존재하는 카테고리 등록 시 실패한다.")
+    @Test
+    void createCategory_fail_existsCategory(){
+        // given
+        User admin =
+                createUser("admin@example.com", "qwer123!", "관리자", "01098765432", "남성");
+        userRepository.save(admin);
+        CategoryRequestDto requestDto = createCategoryDto("전자제품", ItemTypeEnum.THING, null);
+        Category category = createCategory(requestDto);
+        categoryRepository.save(category);
+
+        // when // then
+        assertThatThrownBy(() -> adminItemService.createCategory(requestDto, admin))
+                .isInstanceOf(ErrorException.class)
+                .hasMessage(ExceptionEnum.CATEGORY_DUPLICATION.getMsg());
+    }
+
+    @DisplayName("카테고리의 상위 카테고리 등록 시 상위 카테고리가 존재하지 않으면 실패한다.")
+    @Test
+    void createCategory_fail_not_found_parentCategory(){
+        // given
+        User admin =
+                createUser("admin@example.com", "qwer123!", "관리자", "01098765432", "남성");
+        userRepository.save(admin);
+        Category category = Category.builder()
+                .name("과일")
+                .type(ItemTypeEnum.FOOD)
+                .build();
+        categoryRepository.save(category);
+        categoryRepository.deleteById(category.getId());
+        CategoryRequestDto requestDto = createCategoryDto("사과", ItemTypeEnum.FOOD, category);
+
+        // when // then
+        assertThatThrownBy(() -> adminItemService.createCategory(requestDto, admin))
+                .isInstanceOf(ErrorException.class)
+                .hasMessage(ExceptionEnum.CATEGORY_NOT_FOUND.getMsg());
+    }
+
+
+    private User createUser(String email, String password, String name, String tel, String gender) {
+        return User.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .tel(tel)
+                .gender(gender)
+                .role(UserRoleEnum.ADMIN)
+                .build();
+    }
+
+    private CategoryRequestDto createCategoryDto(String name, ItemTypeEnum type, Category parent) {
+        return CategoryRequestDto.builder()
+                .name(name)
+                .type(type)
+                .parent(parent)
+                .build();
+    }
+
+    private Category createCategory(CategoryRequestDto requestDto) {
+        return Category.builder()
+                .name(requestDto.getName())
+                .type(requestDto.getType())
+                .parent(requestDto.getParent())
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 개요
AdminItemService의 createCategory, createBrand 메서드에 대한 통합 테스트를 추가했습니다.

## 주요 변경 사항
- 카테고리 등록 관련 테스트
  - 관리자 권한으로 카테고리 등록 성공
  - 일반 유저가 등록 시 권한 예외 발생
  - 중복된 이름 등록 시 CATEGORY_DUPLICATION 예외 발생
  - 존재하지 않는 상위 카테고리 지정 시 CATEGORY_NOT_FOUND 예외 발생

- 브랜드 등록 관련 테스트
  - 관리자 권한으로 브랜드 등록 성공
  - 일반 유저가 등록 시 권한 예외 발생
  - 중복된 이름 등록 시 BRAND_DUPLICATION 예외 발생

## 기타
- 테스트 실행 후 DB 정리를 위한 `@AfterEach` 메서드 추가
- 테스트용 빌더 메서드(`createUser`, `createCategoryDto` 등) 활용으로 중복 제거