### PR TITLE
feat: Redis 설정 및 로그아웃 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.apache.commons:commons-pool2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/coupangclone/auth/service/TokenService.java
+++ b/src/main/java/com/example/coupangclone/auth/service/TokenService.java
@@ -1,0 +1,54 @@
+package com.example.coupangclone.auth.service;
+
+import com.example.coupangclone.auth.jwt.JwtProvider;
+import com.example.coupangclone.config.RedisUtil;
+import com.example.coupangclone.global.exception.ErrorException;
+import com.example.coupangclone.global.exception.ExceptionEnum;
+import com.example.coupangclone.user.entity.User;
+import com.example.coupangclone.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final RedisUtil redisUtil;
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    public User verifyRefreshToken(String refreshToken) {
+        if (!jwtProvider.validationToken(refreshToken)) {
+            throw new ErrorException(ExceptionEnum.EXPIRED_TOKEN);
+        }
+
+        Claims claims = jwtProvider.getUserInfoFromToken(refreshToken);
+        String userId = claims.get("userId").toString();
+        String redisToken = redisUtil.get("RT:" + userId);
+
+        if (!refreshToken.equals(redisToken)) {
+            throw new ErrorException(ExceptionEnum.INVALID_TOKEN);
+        }
+
+        return userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new ErrorException(ExceptionEnum.USER_NOT_FOUND));
+    }
+
+    public void logout(String accessToken, String refreshToken) {
+        if (accessToken == null || refreshToken == null) {
+            throw new ErrorException(ExceptionEnum.INVALID_TOKEN);
+        }
+
+        Claims claims = jwtProvider.getUserInfoFromToken(refreshToken);
+        Long userId = claims.get("userId", Long.class);
+
+        redisUtil.delete("RT:" + userId);
+
+        long expiration = jwtProvider.getExpiration(accessToken);
+        redisUtil.set("BL:" + accessToken, "logout", expiration, TimeUnit.MILLISECONDS);
+    }
+
+}

--- a/src/main/java/com/example/coupangclone/config/RedisConfig.java
+++ b/src/main/java/com/example/coupangclone/config/RedisConfig.java
@@ -1,0 +1,21 @@
+package com.example.coupangclone.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+
+}

--- a/src/main/java/com/example/coupangclone/config/RedisUtil.java
+++ b/src/main/java/com/example/coupangclone/config/RedisUtil.java
@@ -1,0 +1,34 @@
+package com.example.coupangclone.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+public class RedisUtil {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public RedisUtil(@Qualifier("redisTemplate") RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void set(String key, String value, long duration, TimeUnit unit) {
+        redisTemplate.opsForValue().set(key, value, duration, unit);
+    }
+
+    public String get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public boolean hasKey(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+}

--- a/src/main/java/com/example/coupangclone/config/SwaggerConfig.java
+++ b/src/main/java/com/example/coupangclone/config/SwaggerConfig.java
@@ -20,8 +20,11 @@ public class SwaggerConfig {
                 .version("v1.0.0");
 
         String jwtSchemeName = "jwtAuth";
+        String refreshTokenSchemeName = "refreshTokenAuth";
 
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList(jwtSchemeName)
+                .addList(refreshTokenSchemeName);
 
         SecurityScheme securityScheme = new SecurityScheme()
                 .name(jwtSchemeName)
@@ -29,9 +32,18 @@ public class SwaggerConfig {
                 .scheme("bearer")
                 .bearerFormat("JWT");
 
+        SecurityScheme refreshTokenScheme = new SecurityScheme()
+                .name(refreshTokenSchemeName)
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name("Refresh-Token");
+
         return new OpenAPI()
                 .info(info)
                 .addSecurityItem(securityRequirement)
-                .components(new Components().addSecuritySchemes(jwtSchemeName, securityScheme));
+                .components(new Components()
+                        .addSecuritySchemes(jwtSchemeName, securityScheme)
+                        .addSecuritySchemes(refreshTokenSchemeName, refreshTokenScheme)
+                );
     }
 }

--- a/src/main/java/com/example/coupangclone/user/controller/UserController.java
+++ b/src/main/java/com/example/coupangclone/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.example.coupangclone.user.dto.SignupRequestDto;
 import com.example.coupangclone.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,12 @@ public class UserController {
     public ResponseEntity<?> login(@RequestBody LoginRequestDto requestDto,
                                     HttpServletResponse response) {
         return userService.login(requestDto, response);
+    }
+
+    @Operation(summary = "로그아웃 (엑세스, 리프레쉬 토큰 모두 상단에 넣어주세요)", description = "사용자가 로그아웃을 합니다.")
+    @PostMapping("/api/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request) {
+        return userService.logout(request);
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,11 @@ spring:
       max-file-size: 10MB
       max-request-size: 20MB
 
+  data:
+    redis:
+      host: 43.200.193.73
+      port: 6379
+
 cloud:
   aws:
     stack:

--- a/src/test/java/com/example/coupangclone/auth/service/TokenServiceTest.java
+++ b/src/test/java/com/example/coupangclone/auth/service/TokenServiceTest.java
@@ -1,0 +1,115 @@
+package com.example.coupangclone.auth.service;
+
+import com.example.coupangclone.auth.jwt.JwtProvider;
+import com.example.coupangclone.config.RedisUtil;
+import com.example.coupangclone.global.exception.ErrorException;
+import com.example.coupangclone.global.exception.ExceptionEnum;
+import com.example.coupangclone.user.entity.User;
+import com.example.coupangclone.user.enums.UserRoleEnum;
+import com.example.coupangclone.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class TokenServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private JwtProvider jwtProvider;
+    @Autowired
+    private RedisUtil redisUtil;
+    @Autowired
+    private TokenService tokenService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createUser("test@example.com", "password", "테스트", "0101111222", "남성");
+        userRepository.save(testUser);
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("RefreshToken이 유효한 경우 사용자 정보를 반환한다.")
+    @Test
+    void verifyRefreshToken_success() {
+        // Given
+        String refreshToken = jwtProvider.createRefreshToken(testUser.getId());
+        redisUtil.set("RT:" + testUser.getId(), refreshToken, 14, TimeUnit.DAYS);
+
+        // When
+        User result = tokenService.verifyRefreshToken(refreshToken);
+
+        // Then
+        assertThat(result.getEmail()).isEqualTo(testUser.getEmail());
+    }
+
+    @DisplayName("유효하지 않은 RefreshToken의 경우 예외 발생한다.")
+    @Test
+    void verifyRefreshToken_invalid() {
+        // Given
+        String invalidRefreshToken = "invalid_refresh_token";
+
+        // When & Then
+        assertThatThrownBy(() -> tokenService.verifyRefreshToken(invalidRefreshToken))
+                .isInstanceOf(ErrorException.class)
+                .hasMessage(ExceptionEnum.INVALID_TOKEN.getMsg());
+    }
+
+    @DisplayName("로그아웃 시 AccessToken과 RefreshToken을 처리한다.")
+    @Test
+    void logout_success() {
+        // Given
+        String accessToken = jwtProvider.createAccessToken(testUser.getId(), testUser.getEmail(), testUser.getName(), testUser.getRole());
+        String refreshToken = jwtProvider.createRefreshToken(testUser.getId());
+        redisUtil.set("RT:" + testUser.getId(), refreshToken, 14, TimeUnit.DAYS);
+
+        // When
+        tokenService.logout(accessToken.substring(7), refreshToken);
+
+        // Then
+        assertThat(redisUtil.get("RT:" + testUser.getId())).isNull();
+        assertThat(redisUtil.get("BL:" + accessToken.substring(7))).isEqualTo("logout");
+    }
+
+    @DisplayName("로그아웃 시 토큰 값이 없다면 예외가 발생한다.")
+    @Test
+    void logout_invalidTokens() {
+        // Given
+        String accessToken = null;
+        String refreshToken = null;
+
+        // When & Then
+        assertThatThrownBy(() -> tokenService.logout(accessToken, refreshToken))
+                .isInstanceOf(ErrorException.class)
+                .hasMessage(ExceptionEnum.INVALID_TOKEN.getMsg());
+    }
+
+    private User createUser(String email, String password, String name, String tel, String gender) {
+        return User.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .tel(tel)
+                .gender(gender)
+                .role(UserRoleEnum.USER)
+                .build();
+    }
+
+}


### PR DESCRIPTION
### 변경 사항
- **Redis 설정**: Redis 호스트를 EC2 환경에 맞게 설정 (IP: 43.200.193.73, 포트: 6379)
- **로그아웃 기능**: 
  - `TokenService`와 `UserService`에 로그아웃 기능 추가
  - RefreshToken 삭제 및 AccessToken 블랙리스트 등록 처리
- **JWT 인증 필터**:
  - RefreshToken 검증 및 만료된 AccessToken 자동 재발급 처리
- **Swagger**: 로그아웃 API에 대한 설명 추가
- **테스트 코드**: 로그아웃 기능에 대한 통합 테스트 작성

### 설명
- EC2 환경에 맞게 Redis 설정을 변경하고, 로그아웃 기능을 추가하여 **Redis**와 **JWT** 인증 관련 작업을 개선
- 로그아웃 시 **RefreshToken 삭제** 및 **AccessToken 블랙리스트 등록**을 처리하고, 만료된 토큰에 대해 **RefreshToken을 통한 자동 재발급**을 구현
- 로그아웃 기능에 대한 **테스트**를 작성하여 정상 동작을 검증