### PR TITLE
feat: SonarQube 코드 분석 및 테스트 커버리지 설정 추가

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -48,8 +48,17 @@ jacoco {
     toolVersion = "0.8.10"
 }
 
-jacocoTestReport {
-    dependsOn test
+tasks.named('test') {
+    useJUnitPlatform()
+    systemProperty 'spring.profiles.active', 'test'
+    systemProperty 'spring.config.location', 'classpath:/yaml/'
+    systemProperty 'spring.config.name', 'application,application-secret,application-test'
+
+    finalizedBy 'jacocoTestReport'
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn 'test'
     reports {
         xml.required = true
         html.required = true

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,7 +1,19 @@
 plugins {
     id 'org.springframework.boot' version '3.2.5'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
     id 'java'
+}
+
+apply plugin: 'org.sonarqube'
+
+sonarqube {
+    properties {
+        property "sonar.sources", "src/main/java"
+        property "sonar.tests", "src/test/java"
+        property "sonar.java.binaries", "build/classes/java/main"
+        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
+    }
 }
 
 bootJar {
@@ -30,4 +42,17 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+}
+
+jacoco {
+    toolVersion = "0.8.10"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,13 +44,6 @@ subprojects {
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	}
 
-	test {
-		useJUnitPlatform()
-		systemProperty 'spring.profiles.active', 'test'
-		systemProperty 'spring.config.location', 'classpath:/yaml/'
-		systemProperty 'spring.config.name', 'application,application-secret,application-test'
-	}
-
 	sourceSets {
 		main {
 			resources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,16 @@
 plugins {
 	id 'org.springframework.boot' version '3.2.5' apply false
 	id 'io.spring.dependency-management' version '1.1.7'apply false
+	id "org.sonarqube" version "4.4.1.3373"
 	id 'java'
+}
+
+sonarqube {
+	properties {
+		property "sonar.projectKey", "coupang-clone"
+		property "sonar.host.url", "http://localhost:9000"
+		property "sonar.login", System.getenv("SONAR_TOKEN")
+	}
 }
 
 allprojects {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,6 +4,16 @@ plugins {
     id 'java'
 }
 
+apply plugin: 'org.sonarqube'
+
+sonarqube {
+    properties {
+        property "sonar.sources", "src/main/java"
+        property "sonar.tests", ""
+        property "sonar.java.binaries", "build/classes/java/main"
+    }
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     // valid

--- a/common/src/main/java/com/example/coupangclone/exception/ExceptionEnum.java
+++ b/common/src/main/java/com/example/coupangclone/exception/ExceptionEnum.java
@@ -19,7 +19,9 @@ public enum ExceptionEnum {
     BRAND_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "브랜드를 찾을 수 없습니다..", "ITEM"),
     CATEGORY_DUPLICATION(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 카테고리입니다.", "ITEM"),
     BRAND_DUPLICATION(HttpStatus.BAD_REQUEST.value(), "이미 존재하는 브랜드입니다.", "ITEM"),
-    IMAGE_REQUIRED(HttpStatus.BAD_REQUEST.value(), "이미지를 첨부해주세요.", "ITEM");
+    IMAGE_REQUIRED(HttpStatus.BAD_REQUEST.value(), "이미지를 첨부해주세요.", "ITEM"),
+    IMAGE_FILENAME_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "파일 이름이 존재하지 않습니다.", "ITEM"),
+    IMAGE_EXTENSION_MISSING(HttpStatus.BAD_REQUEST.value(), "확장자가 없는 파일은 업로드 할 수 없습니다.", "ITEM");
 
     private final int status;
     private final String msg;

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -49,8 +49,17 @@ jacoco {
     toolVersion = "0.8.10"
 }
 
-jacocoTestReport {
-    dependsOn test
+tasks.named('test') {
+    useJUnitPlatform()
+    systemProperty 'spring.profiles.active', 'test'
+    systemProperty 'spring.config.location', 'classpath:/yaml/'
+    systemProperty 'spring.config.name', 'application,application-secret,application-test'
+
+    finalizedBy(tasks.named('jacocoTestReport'))
+}
+
+tasks.named('jacocoTestReport') {
+    dependsOn(tasks.named('test'))
     reports {
         xml.required = true
         html.required = true

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -1,7 +1,19 @@
 plugins {
     id 'org.springframework.boot' version '3.2.5'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
     id 'java'
+}
+
+apply plugin: 'org.sonarqube'
+
+sonarqube {
+    properties {
+        property "sonar.sources", "src/main/java"
+        property "sonar.tests", "src/test/java"
+        property "sonar.java.binaries", "build/classes/java/main"
+        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
+    }
 }
 
 dependencies {
@@ -31,4 +43,17 @@ bootJar {
 
 jar {
     enabled = true
+}
+
+jacoco {
+    toolVersion = "0.8.10"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
 }

--- a/domain/src/main/java/com/example/coupangclone/service/item/ItemService.java
+++ b/domain/src/main/java/com/example/coupangclone/service/item/ItemService.java
@@ -163,9 +163,9 @@ public class ItemService {
     }
 
     private void checkUser(User user) {
-        userRepository.findByEmail(user.getEmail()).orElseThrow(
-                () -> new ErrorException(ExceptionEnum.USER_NOT_FOUND)
-        );
+        if (!userRepository.findByEmail(user.getEmail()).isPresent()) {
+            throw new ErrorException(ExceptionEnum.USER_NOT_FOUND);
+        }
     }
 
 }

--- a/domain/src/test/java/com/example/coupangclone/item/service/item/AdminItemServiceTest.java
+++ b/domain/src/test/java/com/example/coupangclone/item/service/item/AdminItemServiceTest.java
@@ -37,9 +37,6 @@ class AdminItemServiceTest {
     @Autowired
     private BrandRepository brandRepository;
 
-    AdminItemServiceTest() {
-    }
-
     @AfterEach
     void tearDown() {
         brandRepository.deleteAllInBatch();

--- a/domain/src/test/java/com/example/coupangclone/item/service/item/ItemServiceTest.java
+++ b/domain/src/test/java/com/example/coupangclone/item/service/item/ItemServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -65,6 +66,7 @@ class ItemServiceTest {
     @TestConfiguration
     static class TestS3Config {
         @Bean
+        @Primary
         public S3UploadPort s3UploadPort() {
             return new FakeS3Uploader();
         }

--- a/infra/build.gradle
+++ b/infra/build.gradle
@@ -4,6 +4,16 @@ plugins {
     id 'java'
 }
 
+apply plugin: 'org.sonarqube'
+
+sonarqube {
+    properties {
+        property "sonar.sources", "src/main/java"
+        property "sonar.tests", ""
+        property "sonar.java.binaries", "build/classes/java/main"
+    }
+}
+
 dependencies {
     implementation project(':common')
     implementation project(':domain')

--- a/infra/src/main/java/com/example/coupangclone/s3/S3Uploader.java
+++ b/infra/src/main/java/com/example/coupangclone/s3/S3Uploader.java
@@ -3,6 +3,8 @@ package com.example.coupangclone.s3;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.example.coupangclone.auth.S3UploadPort;
+import com.example.coupangclone.exception.ErrorException;
+import com.example.coupangclone.exception.ExceptionEnum;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -21,6 +23,15 @@ public class S3Uploader implements S3UploadPort {
     @Override
     public String upload(MultipartFile multipartFile) throws IOException {
         String originalFileName = multipartFile.getOriginalFilename();
+
+        if (originalFileName == null) {
+            throw new ErrorException(ExceptionEnum.IMAGE_FILENAME_NOT_FOUND);
+        }
+
+        if (!originalFileName.contains(".")) {
+            throw new ErrorException(ExceptionEnum.IMAGE_EXTENSION_MISSING);
+        }
+
         String fileExtension = getFileExtension(originalFileName);
 
         if (!isValidImageExtension(fileExtension)) {


### PR DESCRIPTION
## 📌 주요 변경 사항
- SonarQube 분석을 위한 `org.sonarqube` Gradle 플러그인 적용
- 테스트 커버리지 측정을 위한 Jacoco 설정 추가
- `sonar.login` 토큰은 환경변수(SONAR_TOKEN)로 관리
- 멀티 모듈 구조에서 테스트 코드가 있는 `api`, `domain` 모듈에만 Jacoco 적용

## 🧪 실행 방법
```bash
# 환경변수 설정 (예시: PowerShell)
$env:SONAR_TOKEN="token"

# 분석 실행
./gradlew clean test jacocoTestReport sonar
```